### PR TITLE
fix: Wrong File Size (over 4GB) during readdir

### DIFF
--- a/websocket-sftp/lib/sftp-misc.ts
+++ b/websocket-sftp/lib/sftp-misc.ts
@@ -460,7 +460,7 @@ export class SftpAttributes implements IStats {
 
       if (typeof stats.size !== "undefined") {
         flags |= SftpAttributeFlags.SIZE;
-        this.size = stats.size | 0;
+        this.size = stats.size ?? 0;
       }
 
       if (


### PR DESCRIPTION
I found this bug when a folder contains a >4GB file, the size is incorrect when I do `ls -lah ./my/websocket/fuse/path`

Example ls output (before)
```sh
$ ls -lah ~/mnt/from
total 37G
drwxr-xr-x 1 roy roy 4.0K Sep 13 22:00 .
drwxr-xr-x 4 roy roy 4.0K Sep 11 23:16 ..
-rwxr-xr-x 1 roy roy 587M Sep 12 23:38 cm.mkv
-rw-r--r-- 1 roy roy 1.8G Sep  7 23:25 dune.mkv
-rw-r--r-- 1 roy roy 2.5G Sep 12 01:13 dune-transcoded.mp4
```


Example ls output (after)
```sh
$ ls -lah ~/mnt/from
total 37G
drwxr-xr-x 1 roy roy 4.0K Sep 13 22:00 .
drwxr-xr-x 4 roy roy 4.0K Sep 11 23:16 ..
-rwxr-xr-x 1 roy roy 4.6G Sep 12 23:38 cm.mkv
-rw-r--r-- 1 roy roy  30G Sep  7 23:25 dune.mkv
-rw-r--r-- 1 roy roy 2.5G Sep 12 01:13 dune-transcoded.mp4
```

I believe it is an typo in the code when the writing the size bit of  the sftp packet.