### PR TITLE
Error Writing file with file size >2GB

### DIFF
--- a/websocket-sftp/lib/sftp-packet.ts
+++ b/websocket-sftp/lib/sftp-packet.ts
@@ -161,18 +161,17 @@ export class SftpPacketReader extends SftpPacket {
   }
 
   readInt64(): number {
-    const hi = this.readInt32();
-    const lo = this.readUInt32();
-
-    const value = hi * 0x100000000 + lo;
-    return value;
+    this.check(8);
+    const value = this.buffer.readBigInt64BE(this.position);
+    this.position += 8;
+    return Number(value);
   }
 
   readUInt64(): number {
-    const hi = this.readUInt32();
-    const lo = this.readUInt32();
-    const value = hi * 0x100000000 + lo;
-    return value;
+    this.check(8);
+    const value = this.buffer.readBigUint64BE(this.position);
+    this.position += 8;
+    return Number(value);
   }
 
   readString(): string {
@@ -271,17 +270,15 @@ export class SftpPacketWriter extends SftpPacket {
   }
 
   writeInt64(value: number): void {
-    const hi = (value / 0x100000000) | 0;
-    const lo = (value & 0xffffffff) | 0;
-    this.writeInt32(hi);
-    this.writeInt32(lo);
+    this.check(8);
+    this.buffer.writeBigInt64BE(BigInt(value), this.position);
+    this.position += 8;
   }
 
   writeUInt64(value: number): void {
-    const hi = (value / 0x100000000) | 0;
-    const lo = (value & 0xffffffff) | 0;
-    this.writeUInt32(hi);
-    this.writeUInt32(lo);
+    this.check(8);
+    this.buffer.writeBigUInt64BE(BigInt(value), this.position);
+    this.position += 8;
   }
 
   writeString(value: string): void {


### PR DESCRIPTION
Normal case `var value = 2147450880`: 
```js
$ node
Welcome to Node.js v20.17.0.
Type ".help" for more information.
> var value = 2147450880
undefined
> var hi = (value / 0x100000000) | 0;
undefined
> var lo = (value & 0xffffffff) | 0;
undefined
> hi
0
> lo
2147450880
```
`lo` is still positive

Error case `var value2 = 2147659776`:
```js
> var value2 = 2147659776
undefined
> var hi2 = (value2 / 0x100000000) | 0;
undefined
> var lo2 = (value2 & 0xffffffff) | 0;
undefined
> hi2
0
> lo2
-2147307520
```

`lo2` becomes `-2147307520` indicate an overflow

This fix use js native `buffer.writeBigUInt64BE` and `buffer.readBigUInt64BE` to write js Number into a 64 bit buffer